### PR TITLE
Fix StochasticDiffEq API compatibility

### DIFF
--- a/make.jl
+++ b/make.jl
@@ -5,7 +5,7 @@ targetpath_examples = get(ENV, "TARGETPATH_EXAMPLES", "../QuantumOptics.jl-docum
 jupyter_kernel_name = "julia"
 
 using IJulia
-IJulia.installkernel(jupyter_kernel_name; specname=jupyter_kernel_name, displayname=jupyter_kernel_name)
+IJulia.installkernel(jupyter_kernel_name, "--project=@."; specname=jupyter_kernel_name, displayname=jupyter_kernel_name)
 
 if !isdir(markdowndir)
     println("Creating markdown output directory at \"", markdowndir, "\"")
@@ -32,7 +32,7 @@ end
 
 overwrite = true
 
-Threads.@threads for name in names
+for name in names
     mdname = name[1:end-6] * ".md"
     if overwrite || !isfile(joinpath(markdowndir, mdname))
         # Convert notebook to julia file

--- a/notebooks/atom-dephasing.ipynb
+++ b/notebooks/atom-dephasing.ipynb
@@ -125,20 +125,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Average over stochastic Schrödinger equations\n",
-    "fout(t, psi) = real(expect(sz, psi))\n",
-    "\n",
-    "# Import StochasticDiffEq to use different algorithm\n",
-    "import StochasticDiffEq\n",
-    "\n",
-    "Ntraj = 250\n",
-    "z_avg = zero(T)\n",
-    "for i=1:Ntraj\n",
-    "    t, z = stochastic.schroedinger(T, ψ0, H, Hs; fout=fout, alg=StochasticDiffEq.RKMil{:Stratonovich}())\n",
-    "    z_avg .+= z./Ntraj\n",
-    "end"
-   ]
+   "source": "# Average over stochastic Schrödinger equations\nfout(t, psi) = real(expect(sz, psi))\n\n# Import StochasticDiffEq to use different algorithm\nimport StochasticDiffEq\n\nNtraj = 250\nz_avg = zero(T)\nfor i=1:Ntraj\n    t, z = stochastic.schroedinger(T, ψ0, H, Hs; fout=fout, alg=StochasticDiffEq.RKMil(interpretation=StochasticDiffEq.SciMLBase.AlgorithmInterpretation.Stratonovich))\n    z_avg .+= z./Ntraj\nend"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
Updates notebooks and build script for compatibility with latest StochasticDiffEq.jl API.

## Changes
- **atom-dephasing.ipynb**: Updated to use new algorithm interpretation syntax
  - Changed from deprecated `StochasticDiffEq.RKMil{:Stratonovich}()` 
  - To: `StochasticDiffEq.RKMil(interpretation=StochasticDiffEq.SciMLBase.AlgorithmInterpretation.Stratonovich)`
  
- **make.jl**: Improved build process
  - Install Jupyter kernel with project environment (`--project=@.`)
  - Run notebooks sequentially instead of in parallel to avoid ZMQ resource exhaustion

## Testing
All 22 notebooks now convert successfully without errors when running `julia --project=. make.jl`.

## Breaking Changes
The old `StochasticDiffEq.RKMil{:Stratonovich}()` syntax is no longer supported in recent versions of StochasticDiffEq.jl. This PR updates to the new required syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)